### PR TITLE
set the dashboard link if on jupyterhub

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,10 +39,19 @@ cluster = dask_hpcconfig.cluster(name)
 where `name` is the name of one of the available clusters.
 
 To override any particular setting:
+For example on 'datarmor-local' to use only 7 workers for increasing memory size of each worker: 
 ```python
-overrides = {"cluster.cores": 14, "distributed.worker.memory.target": 0.91}
-cluster = dask_hpcconfig.cluster(name, **overrides)
+overrides = {"cluster.n_workers": 7}
+cluster = dask_hpcconfig.cluster("datarmor-local", **overrides)
 ```
+
+For example on 'datarmor' to use only 7 workers for increasing memory size of each worker, and use 49 workers (i.e. 7 mpi_1 nodes) : 
+```python
+overrides = {"cluster.cores": 7}
+cluster = dask_hpcconfig.cluster("datarmor", **overrides)
+cluster.scale(49)
+```
+
 
 `cluster` can then be used to create a `Client`:
 ```python

--- a/dask_hpcconfig/clusters.yaml
+++ b/dask_hpcconfig/clusters.yaml
@@ -55,7 +55,7 @@ datarmor-seq:
     cores: 1
     memory: '120GB'
     processes: 1
-    queue: seq
+    queue: sequentiel
     death-timeout: 250
     resource-spec: select=1:ncpus=1:mem=4GB
     job-extra: [-m n]

--- a/dask_hpcconfig/clusters.yaml
+++ b/dask_hpcconfig/clusters.yaml
@@ -46,3 +46,30 @@ datarmor:
         terminate: 0.99  # fraction at which we terminate the worker
     comm:
       compression: null
+      
+
+datarmor-seq:
+  cluster:
+    type: pbs
+    name: dask-worker-datarmor
+    cores: 1
+    memory: '120GB'
+    processes: 1
+    queue: seq
+    death-timeout: 250
+    resource-spec: select=1:ncpus=1:mem=4GB
+    job-extra: [-m n]
+    interface: "ib0"
+    walltime: "12:00:00"
+    local-directory: "$TMPDIR"
+  distributed:
+    scheduler:
+      bandwidth: 10000000000    # 10000 MB/s estimated worker-worker bandwidth with IB, it should go better...
+    worker:
+      memory:
+        target: 0.90  # Avoid spilling to disk
+        spill: 0  # Avoid spilling to disk
+        pause: 0.95  # fraction at which we pause worker threads
+        terminate: 0.99  # fraction at which we terminate the worker
+    comm:
+      compression: null


### PR DESCRIPTION
- [x] closes #7

This does not solve the issue with the worker logs not being accessible, but I suspect that's a bug in `dask-labextension` and that there's not much we can do to work around this (but I might be wrong).